### PR TITLE
Remove coverage_report from tt_skip

### DIFF
--- a/.tt_skip
+++ b/.tt_skip
@@ -1,5 +1,4 @@
 data_managers/data_manager_rsync_g2/
-tools/coverage_report/
 tools/ebi_tools/
 tools/enasearch
 tools/qiime


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [x] This PR does something else (explain below)

From #7834, removed the coverage_report from being skipped 

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
